### PR TITLE
Set location when getting BigQuery job status

### DIFF
--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryHelper.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryHelper.java
@@ -357,7 +357,16 @@ public class BigQueryHelper {
             "Fetching existing job after catching exception for duplicate jobId '%s'",
             job.getJobReference().getJobId());
         try {
-          response = service.jobs().get(projectId, job.getJobReference().getJobId()).execute();
+          if (job.getJobReference().getLocation()!=null) {
+            response =
+                    service
+                            .jobs()
+                            .get(projectId, job.getJobReference().getJobId())
+                            .setLocation(job.getJobReference().getLocation())
+                            .execute();
+          } else {
+            response = service.jobs().get(projectId, job.getJobReference().getJobId()).execute();
+          }
         } catch (IOException getJobException) {
           getJobException.addSuppressed(insertJobException);
           throw new IOException(

--- a/gcs/INSTALL.md
+++ b/gcs/INSTALL.md
@@ -121,3 +121,15 @@ the installation.
     [gsutil](https://cloud.google.com/storage/docs/gsutil) (`gsutil ls -b
     gs://<some-bucket>`), and that the credentials in your configuration are
     correct.
+*   To troubleshot other issues run `hadoop fs` command with debug logs:
+    ```
+    $ cat <<EOF > "/tmp/google-logging.properties"
+    handlers = java.util.logging.ConsoleHandler
+    java.util.logging.ConsoleHandler.level = CONFIG
+    com.google.level = CONFIG
+    EOF
+
+    $ export HADOOP_CLIENT_OPTS="-Djava.util.logging.config.file=/tmp/google-logging.properties"
+
+    $ hadoop --loglevel debug fs -ls gs://<some-bucket>
+    ```

--- a/gcs/INSTALL.md
+++ b/gcs/INSTALL.md
@@ -107,6 +107,7 @@ the installation.
 
 *   If the installation test reported `No FileSystem for scheme: gs`, make sure
     that you correctly set the two properties in the correct `core-site.xml`.
+
 *   If the test reported `java.lang.ClassNotFoundException:
     com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem`, check that you added
     the connector to the Hadoop/Spark classpath. If this error caused by
@@ -116,12 +117,15 @@ the installation.
     case, Guava); using a
     [shaded version](https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-latest.jar)
     of the `gcs-connector` jar can resolve this.
+
 *   If the test issued a message related to authorization, make sure that you
     have access to Cloud Storage using
     [gsutil](https://cloud.google.com/storage/docs/gsutil) (`gsutil ls -b
     gs://<some-bucket>`), and that the credentials in your configuration are
     correct.
+
 *   To troubleshot other issues run `hadoop fs` command with debug logs:
+
     ```
     $ cat <<EOF > "/tmp/google-logging.properties"
     handlers = java.util.logging.ConsoleHandler

--- a/gcs/INSTALL.md
+++ b/gcs/INSTALL.md
@@ -127,7 +127,7 @@ the installation.
 *   To troubleshot other issues run `hadoop fs` command with debug logs:
 
     ```
-    $ cat <<EOF > "/tmp/google-logging.properties"
+    $ cat <<EOF >"/tmp/google-logging.properties"
     handlers = java.util.logging.ConsoleHandler
     java.util.logging.ConsoleHandler.level = CONFIG
     com.google.level = CONFIG


### PR DESCRIPTION
This fixes issue #431.  When getting a BigQuery job created outside of the default US location, we need to explicitly provide the job location in the get job request.